### PR TITLE
Update Makefile so the README is accurate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ $(DEP):
 vendor: $(DEP)
 	$(PROXY_VARS) $(DEP) ensure
 
+build: build/k8eraid
+
 build/k8eraid: clean vendor
 	GOARCH=$(ARCH) go build -o build/k8eraid $(PACKAGE)/cmd/k8eraid
 


### PR DESCRIPTION
**Describe your changes**
The README had inaccurate instructions for building k8eraid, this aligns the Makefile with the README
